### PR TITLE
Identify SimplifiedBSD in rubyzip: BSD 2-Clause

### DIFF
--- a/lib/license_finder/license/definitions.rb
+++ b/lib/license_finder/license/definitions.rb
@@ -157,7 +157,7 @@ module LicenseFinder
         License.new(
           short_name:  "SimplifiedBSD",
           pretty_name: "Simplified BSD",
-          other_names: ["FreeBSD", "2-clause BSD", "BSD-2-Clause"],
+          other_names: ["FreeBSD", "2-clause BSD", "BSD-2-Clause", "BSD 2-Clause"],
           url:         "http://opensource.org/licenses/bsd-license"
         )
       end


### PR DESCRIPTION
Rubyzip (and possibly others) use "BSD 2-Clause" as the license name:

https://github.com/rubyzip/rubyzip/blob/master/rubyzip.gemspec